### PR TITLE
PR: Fix identical instruction for conditional sprite_size_sel @ funct…

### DIFF
--- a/src/tms9918.cpp
+++ b/src/tms9918.cpp
@@ -419,7 +419,7 @@ uint16_t vdp_sprite_init(uint8_t name, uint8_t priority, uint8_t color)
     if(sprite_size_sel)
         writeByteToVRAM(4*name);
     else
-        writeByteToVRAM(4*name);
+        writeByteToVRAM(name);
     writeByteToVRAM(0x80 | (color & 0xF));
     return addr;
 }


### PR DESCRIPTION
Fixes name attribution for size 0 sprites (8x8 sprites) @ function vdp_sprite_init